### PR TITLE
fix: props lost reactivity

### DIFF
--- a/src/useReactiveMap.ts
+++ b/src/useReactiveMap.ts
@@ -6,24 +6,18 @@ import ReactiveMap from './ReactiveMap'
 export default function useReactiveMap<K, V>(
   entires?: MapConstructorArgument<K, V>
 ) {
-  const version = ref(1)
-
   function onMutate() {
-    version.value += 1
+    map.value = map.value
   }
 
   const inner = ref(new ReactiveMap<K, V>(onMutate, entires))
 
   const map = computed<Map<K, V>>({
     get: () => {
-      // By using `version` we tell Vue that this property depends on it,
-      // so it gets re-evaluated whenever `version` changes
-      version.value
       return inner.value
     },
     set: (map: Map<K, V>) => {
       inner.value = new ReactiveMap(onMutate, map)
-      version.value += 1
     },
   })
 

--- a/src/useReactiveSet.ts
+++ b/src/useReactiveSet.ts
@@ -4,24 +4,18 @@ import type { SetConstructorArgument } from './types'
 import ReactiveSet from './ReactiveSet'
 
 export default function useReactiveSet<T>(values?: SetConstructorArgument<T>) {
-  const version = ref(1)
-
   function onMutate() {
-    version.value += 1
+    set.value = set.value
   }
 
   const inner = ref(new ReactiveSet<T>(onMutate, values))
 
   const set = computed<Set<T>>({
     get: () => {
-      // By using `version` we tell Vue that this property depends on it,
-      // so it gets re-evaluated whenever `version` changes
-      version.value
       return inner.value
     },
     set: (set: Set<T>) => {
       inner.value = new ReactiveSet(onMutate, set)
-      version.value += 1
     },
   })
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,5 +1,5 @@
 import VueCompositionApi, { defineComponent } from '@vue/composition-api'
-import { createLocalVue, shallowMount } from '@vue/test-utils'
+import { createLocalVue, shallowMount, mount } from '@vue/test-utils'
 
 import { useReactiveMap, useReactiveSet } from '../src'
 
@@ -111,6 +111,43 @@ describe('vue-reactive-collection', () => {
 
       expect(wrapper.find('li').exists()).toBe(false)
     })
+
+    it('should work when passed as a prop', async () => {
+      const Child = defineComponent({
+        props: {
+          map: {
+            type: Map,
+            required: true,
+          },
+        },
+        template:
+          '<ul><li v-for="([key, value]) in map" :key="key">{{ value }}</li></ul>',
+      })
+
+      const Component = defineComponent({
+        components: { Child },
+        setup() {
+          const map = useReactiveMap<string, string>()
+
+          function add() {
+            map.value.set('foo', 'bar')
+          }
+
+          return {
+            map,
+            add,
+          }
+        },
+        template:
+          '<div><button type="button" @click="add">Add Item</button><child :map="map" /></div>',
+      })
+      const wrapper = mount(Component, { localVue })
+
+      wrapper.find('button').trigger('click')
+      await wrapper.vm.$nextTick()
+
+      expect(wrapper.find('li').text()).toBe('bar')
+    })
   })
 
   describe('useReactiveSet', () => {
@@ -216,6 +253,43 @@ describe('vue-reactive-collection', () => {
       await wrapper.vm.$nextTick()
 
       expect(wrapper.find('li').exists()).toBe(false)
+    })
+
+    it('should work when passed as a prop', async () => {
+      const Child = defineComponent({
+        props: {
+          set: {
+            type: Set,
+            required: true,
+          },
+        },
+        template:
+          '<ul><li v-for="item in set" :key="item">{{ item }}</li></ul>',
+      })
+
+      const Component = defineComponent({
+        components: { Child },
+        setup() {
+          const set = useReactiveSet<string>()
+
+          function add() {
+            set.value.add('foo')
+          }
+
+          return {
+            set,
+            add,
+          }
+        },
+        template:
+          '<div><button type="button" @click="add">Add Item</button><child :set="set" /></div>',
+      })
+      const wrapper = mount(Component, { localVue })
+
+      wrapper.find('button').trigger('click')
+      await wrapper.vm.$nextTick()
+
+      expect(wrapper.find('li').text()).toBe('foo')
     })
   })
 })


### PR DESCRIPTION
## Describe the PR

Reactivity is lost in child when an instance of `useReactiveSet` or `useReactiveMap` is passed as a prop.



